### PR TITLE
Update transfer_learning.ipynb  - fix initial_epoch for fine tuning

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -930,7 +930,7 @@
         "\n",
         "history_fine = model.fit(train_dataset,\n",
         "                         epochs=total_epochs,\n",
-        "                         initial_epoch=history.epoch[-1],\n",
+        "                         initial_epoch=history.epoch[-1]+1,\n",
         "                         validation_data=validation_dataset)"
       ]
     },


### PR DESCRIPTION
initial_epoch for the fine tuning phase should be 1 more than history.epoch[-1], so that the history_fine.epoch would be [10, 11, ...19], a total of 10 fine tune epochs. Without the '+1', history.epoch is [0, 1, ...9], and history_fine.epoch is [9, 10, ... 19], the epoch index overlaps at 9, fine tune actually trained for 11 epochs, not 10, and the model is actually trained for 21 epochs in total (can confirm it in the x axis of the combined training history curve - 21 data points).

The 'initial_epoch' argument of model.fit() could be loosely interpreted as '# of training already completed (prior to this round of fit())', so if the model has never been trained, initial_epoch=0 (default); in the tutorial, before fine-tune training, model has already trained for 10 epochs, so the initial_epoch should be 10, i.e. history.epoch[-1]+1.